### PR TITLE
Fix rerun-if-changed directive

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 fn main() -> std::io::Result<()> {
-    println!("cargo::rerun-if-changed=minicoro/minicoro.c");
+    println!("cargo::rerun-if-changed=minicoro.c");
     cc::Build::new().file("minicoro.c").compile("aminicoro");
     Ok(())
 }


### PR DESCRIPTION
Previously, Cargo was given a `rerun-if-changed` directive pointing at a nonexistent file, causing a recompile on every build.