### PR TITLE
Fix longjmp from one coroutine to setjmp in another

### DIFF
--- a/minicoro.c
+++ b/minicoro.c
@@ -1,3 +1,5 @@
+/* For pthread_getattr_np, used to learn the thread's stack bounds under ASan. */
+#define _GNU_SOURCE
 #define MINICORO_IMPL
 #include "minicoro.h"
 #include <assert.h>
@@ -78,24 +80,146 @@ char mco_coro_transfer(mco_coro* src, mco_coro* dst, size_t len) {
     return 0;
 }
 
+#define MCO_JMP_BUF_MAX 256
+#define MCO_ABORT_BUF_SIZE (MCO_JMP_BUF_MAX+64)
+
+void mco_abort_land(void* buf);
+
+// Abort-handler support (Fail/Throw-like effects:
+//
+//   jmp_buf  jb;                (glibc x86-64: 200 bytes <= MCO_JMP_BUF_MAX)
+//   mco_coro* origin;           coroutine (NULL = plain thread stack) that ran setjmp
+//   void*    origin_fake_stack; ASan fake-stack handle to restore on landing
+//   int      crossed;           nonzero when the longjmp crossed coroutine stacks
+//
+// The protocol is:
+//   prologue:  mco_abort_prepare(buf);
+//              idx = _setjmp(buf); ...
+//   wrapper:   // possibly on ANOTHER coroutine's stack!
+//              store result;
+//              mco_abort_longjmp(buf, 1);
+//   landing:   mco_abort_land(buf);
+//
+typedef struct {
+    jmp_buf jb;
+    mco_coro* origin;
+    void* origin_fake_stack;
+    int crossed;
+} _mco_abort_ctx;
+
+// The compiler reserves 256+64 bytes.   Fail the build if:
+// - jmp_buf is too big
+typedef char _mco_jmp_buf_within_bound[sizeof(jmp_buf) <= MCO_JMP_BUF_MAX ? 1 : -1];
+// - the layout outgrows the known size
+typedef char _mco_abort_ctx_fits[sizeof(_mco_abort_ctx) <= MCO_ABORT_BUF_SIZE ? 1 : -1];
+// - the layout outgrows the known size on Windows (even if we are on glibc)
+typedef char _mco_abort_ctx_fits_worst_case[
+    sizeof(_mco_abort_ctx) - sizeof(jmp_buf) + MCO_JMP_BUF_MAX <= MCO_ABORT_BUF_SIZE ? 1 : -1];
+
+void mco_abort_prepare(void* buf) {
+    _mco_abort_ctx* ctx = (_mco_abort_ctx*)buf;
+    ctx->origin = mco_running();
+#ifdef _MCO_USE_ASAN
+    if (ctx->origin == NULL) {
+        _mco_asan_capture_thread_stack();
+    }
+#endif
+    ctx->origin_fake_stack = NULL;
+    ctx->crossed = 0;
+}
+
 // Not a coroutine function but used by Fail/Throw-like effects.
 //
 // Calls `body(env)` in a context where any wrapper that calls
 // `mco_abort_longjmp(buf, val)` will unwind back to this call and
 // `mco_abort_call` will return `val`. Returns 0 if body completes normally.
 //
-// `buf` must point to at least `sizeof(jmp_buf)` bytes.
+// `buf` must point to at least MCO_ABORT_BUF_SIZE bytes.
 int mco_abort_call(void* buf, void (*body)(void* env), void* env) {
-    int v = setjmp(*(jmp_buf*)buf);
+    mco_abort_prepare(buf);
+    int v = setjmp(((_mco_abort_ctx*)buf)->jb);
     if (v == 0) {
         body(env);
         return 0;
     }
+    mco_abort_land(buf);
     return v;
 }
 
-// Unwind back to the matching `mco_abort_call`, setting its return value to
-// `val`. Never returns.
+// Unwind back to the matching setjmp, setting its return value to `val`.
+// Never returns. Safe to call from a coroutine stack nested.
 void mco_abort_longjmp(void* buf, int val) {
-    longjmp(*(jmp_buf*)buf, val);
+    _mco_abort_ctx* ctx = (_mco_abort_ctx*)buf;
+    mco_coro* co = mco_running();
+    while (co && co != ctx->origin) {
+        mco_coro* prev = co->prev_co;
+        // Mirror _mco_prepare_jumpout's bookkeeping without switching
+        // contexts: the abandoned coroutine stays suspended forever.
+        co->prev_co = NULL;
+        co->state = MCO_SUSPENDED;
+        if (prev) {
+            prev->state = MCO_RUNNING;
+        }
+        mco_current_co = prev;
+        ctx->crossed = 1;
+        // The handle saved when co's resumer entered it restores the
+        // resumer's fake stack; keep only the origin's.
+        ctx->origin_fake_stack = co->asan_prev_stack;
+        co->asan_prev_stack = NULL;
+#ifdef _MCO_USE_TSAN
+        void* tsan_prev = co->tsan_prev_fiber;
+        co->tsan_prev_fiber = NULL;
+        __tsan_switch_to_fiber(tsan_prev, 0);
+#endif
+        co = prev;
+    }
+#ifdef _MCO_USE_ASAN
+    if (ctx->crossed) {
+        // We are about to move from this coroutine's stack to the origin's.
+        const void* bottom_old = NULL;
+        size_t size_old = 0;
+        __sanitizer_finish_switch_fiber(NULL, &bottom_old, &size_old);
+        if (ctx->origin) {
+            __sanitizer_start_switch_fiber(NULL, ctx->origin->stack_base, ctx->origin->stack_size);
+        } else {
+            __sanitizer_start_switch_fiber(NULL, _mco_asan_main_bottom, _mco_asan_main_size);
+        }
+    }
+#endif
+    longjmp(ctx->jb, val);
+}
+
+#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+void __asan_unpoison_memory_region(void const volatile* addr, size_t size);
+#endif
+
+// Called on the origin stack. When the longjmp crossed coroutine
+// stacks, address sanitization still believes we are on the abandoned
+// coroutine's stack: restore this stack's identity.
+void mco_abort_land(void* buf) {
+    _mco_abort_ctx* ctx = (_mco_abort_ctx*)buf;
+    if (!ctx->crossed) {
+        return;
+    }
+    ctx->crossed = 0;
+#ifdef _MCO_USE_ASAN
+    void* bottom_old = NULL;
+    size_t size_old = 0;
+    char land_here; // approximates the landing stack pointer
+    void* origin_bottom;
+    __sanitizer_finish_switch_fiber(ctx->origin_fake_stack, (const void**)&bottom_old, &size_old);
+    // Unpoison the origin frames the longjmp skipped: everything on this stack
+    // below us is dead, but its shadow still holds the dead frames' redzones,
+    // which would read as wild stack-buffer-overflows once new frames (or an
+    // interceptor's access check) reach those addresses.
+    origin_bottom = ctx->origin ? ctx->origin->stack_base : _mco_asan_main_bottom;
+    if (origin_bottom && (char*)origin_bottom < &land_here) {
+        __asan_unpoison_memory_region(origin_bottom, &land_here - (char*)origin_bottom);
+    }
+    if (ctx->origin) {
+        // Restore state for the origin (or its next yield breaks).
+        __sanitizer_start_switch_fiber(&ctx->origin->asan_prev_stack, ctx->origin->stack_base, ctx->origin->stack_size);
+    }
+#endif
+    ctx->origin_fake_stack = NULL;
 }

--- a/minicoro.c
+++ b/minicoro.c
@@ -189,7 +189,10 @@ void mco_abort_longjmp(void* buf, int val) {
     longjmp(ctx->jb, val);
 }
 
-#if defined(__SANITIZE_ADDRESS__) || (defined(__has_feature) && __has_feature(address_sanitizer))
+#ifndef __has_feature
+# define __has_feature(x) 0
+#endif
+#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)
 void __asan_unpoison_memory_region(void const volatile* addr, size_t size);
 #endif
 

--- a/minicoro.h
+++ b/minicoro.h
@@ -564,6 +564,35 @@ static MCO_FORCE_INLINE size_t _mco_align_forward(size_t addr, size_t align) {
 /* Variable holding the current running coroutine per thread. */
 static MCO_THREAD_LOCAL mco_coro* mco_current_co = NULL;
 
+#ifdef _MCO_USE_ASAN
+#ifdef __linux__
+#include <pthread.h>
+#endif
+/* The plain thread stack's bounds, needed to announce the thread stack as a
+   fiber-switch target (yield-to-thread below, and cross-stack abort handlers
+   in minicoro.c). Captured on the first jumpin from the thread. */
+static MCO_THREAD_LOCAL void* _mco_asan_main_bottom = NULL;
+static MCO_THREAD_LOCAL size_t _mco_asan_main_size = 0;
+
+/* Best effort: on platforms without pthread_getattr_np the bounds stay
+   unknown, degrading same-stack aborts after coroutine use to an "ignoring
+   requested __asan_handle_no_return" warning, never an error. */
+static void _mco_asan_capture_thread_stack(void) {
+#ifdef __linux__
+  pthread_attr_t attr;
+  void* addr = NULL;
+  size_t size = 0;
+  if(_mco_asan_main_bottom != NULL) return;
+  if(pthread_getattr_np(pthread_self(), &attr) != 0) return;
+  if(pthread_attr_getstack(&attr, &addr, &size) == 0) {
+    _mco_asan_main_bottom = addr;
+    _mco_asan_main_size = size;
+  }
+  pthread_attr_destroy(&attr);
+#endif
+}
+#endif
+
 static MCO_FORCE_INLINE void _mco_prepare_jumpin(mco_coro* co) {
   /* Set the old coroutine to normal state and update it. */
   mco_coro* prev_co = mco_running(); /* Must access through `mco_running`. */
@@ -580,6 +609,8 @@ static MCO_FORCE_INLINE void _mco_prepare_jumpin(mco_coro* co) {
     size_t size_old = 0;
     __sanitizer_finish_switch_fiber(prev_co->asan_prev_stack, (const void**)&bottom_old, &size_old);
     prev_co->asan_prev_stack = NULL;
+  } else {
+    _mco_asan_capture_thread_stack();
   }
   __sanitizer_start_switch_fiber(&co->asan_prev_stack, co->stack_base, co->stack_size);
 #endif
@@ -606,6 +637,15 @@ static MCO_FORCE_INLINE void _mco_prepare_jumpout(mco_coro* co) {
   co->asan_prev_stack = NULL;
   if(prev_co) {
     __sanitizer_start_switch_fiber(&prev_co->asan_prev_stack, bottom_old, size_old);
+  } else if(_mco_asan_main_bottom) {
+    /* Announce the thread stack; mco_resume finishes this switch after the
+       context switch lands back there. Without it, the thread keeps running
+       with this coroutine's bounds installed, so any longjmp performed there
+       (a same-stack abort handler after coroutine use) makes ASan skip its
+       unpoisoning with an "ignoring requested __asan_handle_no_return"
+       warning, leaving the jumped-over frames' shadow poisoned -- which later
+       reads as wild stack-buffer-overflows on valid frames. */
+    __sanitizer_start_switch_fiber(&co->asan_prev_stack, _mco_asan_main_bottom, _mco_asan_main_size);
   }
 #endif
 #ifdef _MCO_USE_TSAN
@@ -1807,6 +1847,16 @@ mco_result mco_resume(mco_coro* co) {
   }
   co->state = MCO_RUNNING; /* The coroutine is now running. */
   _mco_jumpin(co);
+#ifdef _MCO_USE_ASAN
+  if(mco_running() == NULL && _mco_asan_main_bottom) {
+    /* Back on the plain thread stack: complete the switch announced by
+       _mco_prepare_jumpout's yield-to-thread branch. */
+    void* bottom_old = NULL;
+    size_t size_old = 0;
+    __sanitizer_finish_switch_fiber(co->asan_prev_stack, (const void**)&bottom_old, &size_old);
+    co->asan_prev_stack = NULL;
+  }
+#endif
   return MCO_SUCCESS;
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,19 +26,21 @@ WASMTIME=wasmtime
 # OUTEXT=.exe
 # RUNNER=
 
-all: testsuite example mt-example simple benchmark mem-stress
+all: testsuite example mt-example simple benchmark mem-stress abort
 
-test: testsuite
+test: testsuite abort
 	$(RUNNER) ./testsuite$(OUTEXT)
+	$(RUNNER) ./abort$(OUTEXT)
 
 test-example: example
 	$(RUNNER) ./example$(OUTEXT)
 
-test-all: testsuite example mt-example simple
+test-all: testsuite example mt-example simple abort
 	$(RUNNER) ./testsuite$(OUTEXT)
 	$(RUNNER) ./example$(OUTEXT)
 	$(RUNNER) ./mt-example$(OUTEXT)
 	$(RUNNER) ./simple$(OUTEXT)
+	$(RUNNER) ./abort$(OUTEXT)
 
 bench: benchmark
 	./benchmark$(OUTEXT)
@@ -61,8 +63,13 @@ benchmark: benchmark.c ../minicoro.h Makefile
 mem-stress: mem-stress.c ../minicoro.h Makefile
 	$(CC) mem-stress.c -o mem-stress $(EXTRA_CFLAGS) $(CFLAGS) -std=gnu11
 
+# Unlike the other tests this one links ../minicoro.c: the abort-handler support
+# it exercises lives there, not in the single-header library.
+abort: abort.c ../minicoro.c ../minicoro.h Makefile
+	$(CC) abort.c ../minicoro.c -o abort $(EXTRA_CFLAGS) $(CFLAGS) -std=c99
+
 clean:
-	rm -f testsuite$(OUTEXT) example$(OUTEXT) mt-example$(OUTEXT) simple$(OUTEXT) benchmark$(OUTEXT)
+	rm -f testsuite$(OUTEXT) example$(OUTEXT) mt-example$(OUTEXT) simple$(OUTEXT) benchmark$(OUTEXT) abort$(OUTEXT)
 
 test-riscv64:
 	$(MAKE) --no-print-directory CC=riscv64-elf-gcc CFLAGS="-march=rv64gc -mabi=lp64d" RUNNER=qemu-riscv64 clean test test-example

--- a/tests/abort.c
+++ b/tests/abort.c
@@ -1,0 +1,135 @@
+/* Cross-coroutine abort handlers. */
+
+#include "minicoro.h"
+#include <assert.h>
+#include <stdio.h>
+
+/* Abort-handler support layer, defined in ../minicoro.c */
+int mco_abort_call(void* buf, void (*body)(void* env), void* env);
+void mco_abort_longjmp(void* buf, int val);
+
+/* The compiler stack-allocates MCO_ABORT_BUF_SIZE = 320 bytes per optimized
+   handle (a jmp_buf padded to the largest known platform's, plus the abort
+   context; see minicoro.c). */
+static char abort_buf[320];
+static mco_coro* co_outer;
+static mco_coro* co_inner;
+
+static void inner_entry(mco_coro* co) {
+  (void)co;
+  assert(mco_running() == co_inner);
+  assert(mco_status(co_outer) == MCO_NORMAL);
+  /* Two coroutine stacks deep: unwind all the way back to main's setjmp. */
+  mco_abort_longjmp(abort_buf, 42);
+  assert(0 && "mco_abort_longjmp returned");
+}
+
+static void outer_entry(mco_coro* co) {
+  (void)co;
+  mco_desc desc = mco_desc_init(inner_entry, 0);
+  assert(mco_create(&co_inner, &desc) == MCO_SUCCESS);
+  assert(mco_resume(co_inner) == MCO_SUCCESS);
+  assert(0 && "resume returned after an abort");
+}
+
+static void body(void* env) {
+  (void)env;
+  mco_desc desc = mco_desc_init(outer_entry, 0);
+  assert(mco_create(&co_outer, &desc) == MCO_SUCCESS);
+  assert(mco_resume(co_outer) == MCO_SUCCESS);
+  assert(0 && "resume returned after an abort");
+}
+
+static void after_entry(mco_coro* co) {
+  assert(mco_running() == co);
+  assert(mco_yield(co) == MCO_SUCCESS);
+}
+
+/* Scenario 1: the abort lands on the plain thread stack. */
+static void abort_to_main(void) {
+  int v;
+  assert(mco_running() == NULL);
+
+  v = mco_abort_call(abort_buf, body, NULL);
+  assert(v == 42);
+
+  /* The longjmp crossed two coroutine stacks. minicoro must agree that we are
+     back on the origin stack with nothing running. */
+  assert(mco_running() == NULL);
+
+  /* Both skipped coroutines are abandoned, never to be resumed again, but must
+     be left in a coherent state rather than still marked running/normal. */
+  assert(mco_status(co_inner) == MCO_SUSPENDED);
+  assert(mco_status(co_outer) == MCO_SUSPENDED);
+
+  mco_destroy(co_inner);
+  mco_destroy(co_outer);
+
+  /* Life goes on: a full resume/yield/resume cycle must work after an abort. */
+  {
+    mco_coro* co_after;
+    mco_desc desc = mco_desc_init(after_entry, 0);
+    assert(mco_create(&co_after, &desc) == MCO_SUCCESS);
+    assert(mco_resume(co_after) == MCO_SUCCESS);
+    assert(mco_status(co_after) == MCO_SUSPENDED);
+    assert(mco_resume(co_after) == MCO_SUCCESS);
+    assert(mco_status(co_after) == MCO_DEAD);
+    assert(mco_running() == NULL);
+    mco_destroy(co_after);
+  }
+}
+
+/* Scenario 2: the setjmp side lives INSIDE a coroutine (an Ante `handle` whose
+   body runs on a coroutine stack), and the abort crosses back to it from a
+   coroutine nested one deeper. */
+static char host_buf[320];
+static mco_coro* co_host;
+static mco_coro* co_aborter;
+
+static void aborter_entry(mco_coro* co) {
+  (void)co;
+  assert(mco_running() == co_aborter);
+  mco_abort_longjmp(host_buf, 7);
+  assert(0 && "mco_abort_longjmp returned");
+}
+
+static void host_body(void* env) {
+  (void)env;
+  mco_desc desc = mco_desc_init(aborter_entry, 0);
+  assert(mco_create(&co_aborter, &desc) == MCO_SUCCESS);
+  assert(mco_resume(co_aborter) == MCO_SUCCESS);
+  assert(0 && "resume returned after an abort");
+}
+
+static void host_entry(mco_coro* co) {
+  int v = mco_abort_call(host_buf, host_body, NULL);
+  assert(v == 7);
+  /* Landed one coroutine up, not on the thread stack. */
+  assert(mco_running() == co_host);
+  assert(mco_status(co_aborter) == MCO_SUSPENDED);
+  /* The host must still be able to yield -- this is where stale bookkeeping
+     shows up: pre-fix the host is not marked running; and if the abort retired
+     the host's pending fiber-switch announcement, the fake stack reactivates
+     and mco_yield's own stack-overflow sanity check trips under ASan. */
+  assert(mco_yield(co) == MCO_SUCCESS);
+}
+
+static void abort_within_coroutine(void) {
+  mco_desc desc = mco_desc_init(host_entry, 0);
+  assert(mco_create(&co_host, &desc) == MCO_SUCCESS);
+  assert(mco_resume(co_host) == MCO_SUCCESS); /* abort + post-abort yield */
+  assert(mco_status(co_host) == MCO_SUSPENDED);
+  assert(mco_running() == NULL);
+  assert(mco_resume(co_host) == MCO_SUCCESS); /* run host to completion */
+  assert(mco_status(co_host) == MCO_DEAD);
+  assert(mco_running() == NULL);
+  mco_destroy(co_host);
+  mco_destroy(co_aborter);
+}
+
+int main(void) {
+  abort_to_main();
+  abort_within_coroutine();
+  printf("abort ok\n");
+  return 0;
+}


### PR DESCRIPTION
Fix longjmp from one coroutine to setjmp in another

`mco_abort_longjmp` could execute on a different coroutine stack than its `setjmp`, leaving state inconsistent.  This case fails when running with address sanitation enabled.

This increases the buffer size on glibc to the current size (which is for Windows) and for Windows increases it beyond the currently allocated maximum.  To avoid having ante check our header to find the size, we simply increase the buffer for all platforms.

Companion PR in ante: https://github.com/jfecher/ante/pull/254